### PR TITLE
Permalinks

### DIFF
--- a/PhDMSR.html
+++ b/PhDMSR.html
@@ -2,6 +2,8 @@
 title: High-Level Synthesis of Neural Networks for FPGAs with LIFT
 
 layout: job_advert
+
+permalink: phdmsr
 ---
 <div id="main">
   <div class="container">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -3,36 +3,36 @@
     <nav id="nav">
         <!-- Collect the nav links, forms, and other content for toggling -->
         <ul class="nav">
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html#events">Events</a></li>
+            <li><a href="index">Home</a></li>
+            <li><a href="index#events">Events</a></li>
             <li class="dropdown">
-	      <a href="index.html#positions">Open positions <span class="caret"></span></a>
+	      <a href="index#positions">Open positions <span class="caret"></span></a>
               <ul class="dropdown-menu">
-		    <li><a href="PhDMSR.html">PhD position</a></li>
+		    <li><a href="phdmsr">PhD position</a></li>
                     <!--<li role="separator" class="divider"></li>
-                    <li><a href="#">Separated link</a></li>-->
+                    <li><a href="index#">Separated link</a></li>-->
                     <div class="dropdown-blur"></div>
                     <div class="dropdown-bg"></div>
                 </ul>
             </li>
-            <!--<li class="active">--><li><a href="index.html#code">Source Code</a></li>
-            <li><a href="index.html#pubs">Publications</a></li>
+            <!--<li class="active">--><li><a href="index#code">Source Code</a></li>
+            <li><a href="index#pubs">Publications</a></li>
             <li class="dropdown">
-                <a href="index.html#research">Reseach directions <span class="caret"></span></a>
+                <a href="index#research">Reseach directions <span class="caret"></span></a>
                 <ul class="dropdown-menu">
-                    <li><a href="algebra.html">Linear Algebra</a></li>
-                    <li><a href="ml.html">Machine Learning</a></li>
-                    <li><a href="reducts_scans.html">Optimising Reductions and Scans</a></li>
-                    <li><a href="sparse_par.html">Sparse Data Parallelism</a></li>
-                    <li><a href="waves.html">3D Wave Modelling</a></li>
-                    <li><a href="stencils.html">Stencil Computations</a></li>
+                    <li><a href="algebra">Linear Algebra</a></li>
+                    <li><a href="ml">Machine Learning</a></li>
+                    <li><a href="reducts_scans">Optimising Reductions and Scans</a></li>
+                    <li><a href="sparse_par">Sparse Data Parallelism</a></li>
+                    <li><a href="waves">3D Wave Modelling</a></li>
+                    <li><a href="stencils">Stencil Computations</a></li>
                     <!--<li role="separator" class="divider"></li>
-                    <li><a href="#">Separated link</a></li>-->
+                    <li><a href="index#">Separated link</a></li>-->
                     <div class="dropdown-blur"></div>
                     <div class="dropdown-bg"></div>
                 </ul>
             </li>
-            <li><a href="index.html#team">Team</a></li>
+            <li><a href="index#team">Team</a></li>
         </ul>
     </nav>
 </div>

--- a/algebra.html
+++ b/algebra.html
@@ -3,6 +3,8 @@ title: Linear Algebra
 subtitle: Matrix Multiplication Beyond Auto-Tuning — Rewrite Based GPU Code Generation
 
 layout: project_page
+
+permalink: algebra
 ---
 <div id="main">
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ title: Home
           </div>
           <center style="margin-top: 20px">
             <span class="button_wrapper" style="align: center;">
-                <a href="ispass2018_tutorial.html" class="button button-style1">Read More</a>
+                <a href="ispass2018" class="button button-style1">Read More</a>
             </span>
           </center>
         <p><!-- 
@@ -103,7 +103,7 @@ title: Home
   <p>
     You can also find below some specific positions currently available:  
           <ul>
-            <li>Fully funded <b>PhD position</b> at Edinburgh University: <a href="PhDMSR.html">High-Level Synthesis of Neural Networks for FPGAs with LIFT</a></li>
+            <li>Fully funded <b>PhD position</b> at Edinburgh University: <a href="phdmsr">High-Level Synthesis of Neural Networks for FPGAs with LIFT</a></li>
           </ul>
   </p>
 
@@ -356,7 +356,7 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
         </header>
         <div class="row">
             <section class="4u">
-                <span class="pennant"><a href="algebra.html"><span class="fa fa-clone"></span></a></span>
+                <span class="pennant"><a href="algebra"><span class="fa fa-clone"></span></a></span>
                 <h3>Linear Algebra</h3>
                 <p>Starting from a single high-level program, our compiler automatically generates highly optimized
                     and specialized matrix multiplication implementations.
@@ -367,22 +367,22 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
                     optimized — but provably correct — implementation of matrix
                     multiplication.</p>
                 <div class="button_wrapper">
-                    <a href="algebra.html" class="button button-style1">Read More</a>
+                    <a href="algebra" class="button button-style1">Read More</a>
                 </div>
             </section>
             <section class="4u">
-                <span class="pennant"><a href="ml.html"><span class="fa fa-connectdevelop"></span></a></span>
+                <span class="pennant"><a href="ml"><span class="fa fa-connectdevelop"></span></a></span>
                 <h3>Machine Learning</h3>
                 <p>Making neural networks (NNs) performance-portable using <span class="lift-bold">Lift</span>:
                     implementing generic and NN-specific optimizations as rewrite rules for efficient hardware utilization;
                     introducing traditional NN building blocks such as <i>conv</i>, <i>norm</i> and <i>fully_connected</i>
                     for seamless integration of <span class="lift-bold">Lift</span> with popular machine learning libraries.</p>
                 <div class="button_wrapper">
-                    <a href="ml.html" class="button button-style1">Read More</a>
+                    <a href="ml" class="button button-style1">Read More</a>
                 </div>
             </section>
             <section class="4u">
-                <span class="pennant"><a href="reducts_scans.html"><span class="fa fa-cubes"></span></a></span>
+                <span class="pennant"><a href="reducts_scans"><span class="fa fa-cubes"></span></a></span>
                 <h3>Optimising Reductions and Scans</h3>
                 <p>Using <span class="lift-bold">Lift</span> to create a high-level programming environment for
                     Heterogeneous Computation, freeing the programmer from the burden of having to write complex
@@ -390,14 +390,14 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
                     non-associative reductions and scans, hence enabling generation of efficient parallel implementations for
                     GPUs.</p>
                 <div class="button_wrapper">
-                    <a href="reducts_scans.html" class="button button-style1">Read More</a>
+                    <a href="reducts_scans" class="button button-style1">Read More</a>
                 </div>
             </section>
         </div>
 
         <div class="row">
             <section class="4u">
-                <span class="pennant"><a href="sparse_par.html"><span class="fa fa-barcode"></span></a></span>
+                <span class="pennant"><a href="sparse_par"><span class="fa fa-barcode"></span></a></span>
                 <h3>Sparse Data Parallelism</h3>
                 <p>We demonstrate that
                     high level programming and high performance GPU execution for
@@ -410,11 +410,11 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
                     of building blocks which capture detailed, low-level implementation
                     choices.</p>
                 <div class="button_wrapper">
-                    <a href="sparse_par.html" class="button button-style1">Read More</a>
+                    <a href="sparse_par" class="button button-style1">Read More</a>
                 </div>
             </section>
             <section class="4u">
-                <span class="pennant"><a href="waves.html"><span class="fa fa-rss"></span></a></span>
+                <span class="pennant"><a href="waves"><span class="fa fa-rss"></span></a></span>
                 <h3>3D Wave Modelling</h3>
                 <p>Simplified room acoustics simulations have been thoroughly investigated in
                     <span class="lift-bold">Lift</span> and a number of other 2D and 3D benchmarks have also been implemented.
@@ -425,11 +425,11 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
                     accommodate these conditions need to be designed and added. Finally, a stencil-based DSL needs to
                     be extended to compile into the <span class="lift-bold">Lift</span> language.</p>
                 <div class="button_wrapper">
-                    <a href="waves.html" class="button button-style1">Read More</a>
+                    <a href="waves" class="button button-style1">Read More</a>
                 </div>
             </section>
             <section class="4u">
-                <span class="pennant"><a href="stencils.html"><span class="fa fa-arrows"></span></a></span>
+                <span class="pennant"><a href="stencils"><span class="fa fa-arrows"></span></a></span>
                 <h3>Stencil Computations</h3>
                 <p>Stencil computations are used in a wide range of
                     applications from physical simulations to machine learning.
@@ -445,7 +445,7 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
                     with a few rewrite rules to achieve performance
                     portability for stencil computations.</p>
                 <div class="button_wrapper">
-                    <a href="stencils.html" class="button button-style1">Read More</a>
+                    <a href="stencils" class="button button-style1">Read More</a>
                 </div>
             </section>
         </div>
@@ -453,21 +453,21 @@ International Conference on Compilers, Architecture and Synthesis for Embedded S
         <div class="row">
             <section class="4u">
                 NOTE: find your icon here: http://fontawesome.io/icons/
-                <span class="pennant"><a href="YOUR_PROJECT_PAGE.html"><span class="fa YOUR_ICON_CODE"></span></a></span>
+                <span class="pennant"><a href="YOUR_PROJECT_PAGE"><span class="fa YOUR_ICON_CODE"></span></a></span>
                 <h3>YOUR_PROJECT_TITLE_SHORT</h3>
                 <p>YOUR_PROJECT_DESCRIPTION</p>
                 <a href="YOUR_PROJECT_PAGE.html" class="button button-style1">Read More</a>
             </section>
             <section class="4u">
                 NOTE: find your icon here: http://fontawesome.io/icons/
-                <span class="pennant"><a href="YOUR_PROJECT_PAGE.html"><span class="fa YOUR_ICON_CODE"></span></a></span>
+                <span class="pennant"><a href="YOUR_PROJECT_PAGE"><span class="fa YOUR_ICON_CODE"></span></a></span>
                 <h3>YOUR_PROJECT_TITLE_SHORT</h3>
                 <p>YOUR_PROJECT_DESCRIPTION</p>
                 <a href="YOUR_PROJECT_PAGE.html" class="button button-style1">Read More</a>
             </section>
             <section class="4u">
                 NOTE: find your icon here: http://fontawesome.io/icons/
-                <span class="pennant"><a href="YOUR_PROJECT_PAGE.html"><span class="fa YOUR_ICON_CODE"></span></a></span>
+                <span class="pennant"><a href="YOUR_PROJECT_PAGE"><span class="fa YOUR_ICON_CODE"></span></a></span>
                 <h3>YOUR_PROJECT_TITLE_SHORT</h3>
                 <p>YOUR_PROJECT_DESCRIPTION</p>
                 <a href="YOUR_PROJECT_PAGE.html" class="button button-style1">Read More</a>

--- a/ispass2018_tutorial.html
+++ b/ispass2018_tutorial.html
@@ -3,6 +3,7 @@ title: ISPASS 2018 tutorial
 subtitle: Lift &mdash; performance portable code generation on parallel accelerators
 
 layout: project_page
+permalink: /ispass2018
 ---
 <div id="main">
     <div class="container">

--- a/ml.html
+++ b/ml.html
@@ -3,6 +3,8 @@ title: Machine Learning
 subtitle: Lift as a cross-platform ML engine
 
 layout: project_page
+
+permalink: /ml
 ---
 <div id="main">
     <div class="container">

--- a/reducts_scans.html
+++ b/reducts_scans.html
@@ -3,6 +3,8 @@ title: Optimising Reductions and Scans
 subtitle: Parallelizing non-associative sequential reductions
 
 layout: project_page
+
+permalink: /reducts_scans
 ---
 <div id="main">
     <div class="container">

--- a/sparse_par.html
+++ b/sparse_par.html
@@ -3,6 +3,8 @@ title: Sparse Data Parallelism
 subtitle: Compositional Compilation for Sparse, Irregular Data Parallelism
 
 layout: project_page
+
+permalink: sparse_par
 ---
 <div id="main">
     <div class="container">

--- a/stencils.html
+++ b/stencils.html
@@ -3,6 +3,8 @@ title: Stencil Computations
 subtitle: Performance-portable stencil code generation with Lift
 
 layout: project_page
+
+permalink: stencils
 ---
 <div id="main">
     <div class="container">

--- a/waves.html
+++ b/waves.html
@@ -3,6 +3,8 @@ title: 3D Wave Modelling
 subtitle: A Modular Approach to Performance, Portability and Productivity for 3D Wave Models
 
 layout: project_page
+
+permalink: waves
 ---
 <div id="main">
     <div class="container">


### PR DESCRIPTION
Added permalinks so that our URLs lose ".html" extensions:
http://www.lift-project.org/ispass2018_tutorial.html 
->
http://www.lift-project.org/ispass2018_tutorial

This is only for aesthetic reasons, looks better on slides.

The branch is temporarly served to [http://artemisa:4000](url) within University network.